### PR TITLE
killall5 feature for nvidia-smi failures

### DIFF
--- a/autopilot-daemon/utils/briefings.sh
+++ b/autopilot-daemon/utils/briefings.sh
@@ -3,15 +3,15 @@ exists=`which nvidia-smi`
 if [[ -z $exists ]]
 then
 	echo !! nvidia-smi not present. ABORT.
-	exit 
+	killall5 
 fi
 
 CMD="$(nvidia-smi)"
-errors="$(echo ${CMD} | grep ERR)"
+errors="$(echo ${CMD} | grep -i err)"
 if [[ -n $errors ]]
 then
 	echo !! nvidia-smi failed to start. ABORT.
-	exit 
+	killall5
 fi
 
 CMD="$(nvidia-smi --query-gpu=mig.mode.current --format=csv)"


### PR DESCRIPTION
This PR introduces a self reboot of the pod when `nvidia-smi` disappears from the pod for any reason (i.e., `nvidia-gpu-operator` problems).

The `killall5` is not added to `mig` or `dcgmi` because these are not that critical to require a full pod restart.