### PR TITLE
Minor updates to Github Actions workflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - 'main'
+    paths:
+      - 'autopilot-daemon/**'
 
 jobs:
   docker:

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -7,8 +7,6 @@ on:
       - 'main'
     paths-ignore:
       - '.github/**'
-    paths:
-      - 'autopilot-daemon/**'
 
 jobs:
   docker:

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -7,6 +7,8 @@ on:
       - 'main'
     paths-ignore:
       - '.github/**'
+    paths:
+      - 'autopilot-daemon/**'
 
 jobs:
   docker:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,8 +3,6 @@ on:
 # For now, we issue new or updated releases manually or when files in the helm chart folder are changed
   push:
     branches: [ "main" ]
-    paths:
-      - 'helm-charts/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR is to avoid launching build and push of the container when changes to non-code path are made, i.e., README.