### PR TITLE
Fix to CPU model parsing

### DIFF
--- a/autopilot-daemon/pkg/utils/prometheus.go
+++ b/autopilot-daemon/pkg/utils/prometheus.go
@@ -37,7 +37,7 @@ func InitHardwareMetrics() {
 	cpu := "N/A"
 
 	cmd := "cat /proc/cpuinfo | egrep '^model name' | uniq | awk '{print substr($0, index($0,$4))}'"
-	out, err := exec.Command("bash", "-c", cmd).Output()
+	out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
 	if err != nil {
 		klog.Info("Error retrieving cpu model info", err.Error())
 	} else {

--- a/autopilot-daemon/pkg/utils/prometheus.go
+++ b/autopilot-daemon/pkg/utils/prometheus.go
@@ -36,7 +36,7 @@ func InitHardwareMetrics() {
 	// Define CPUModel global variable
 	cpu := "N/A"
 
-	cmd := "cat /proc/cpuinfo | egrep '^model name' | uniq | awk '{print substr($0, index($0,$4))}'"
+	cmd := "cat /proc/cpuinfo | egrep '^model name' | uniq | awk '{print substr($0, index($0,$4))}'|  sed 's/(//; s/)//'"
 	out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
 	if err != nil {
 		klog.Info("Error retrieving cpu model info", err.Error())

--- a/autopilot-daemon/pkg/utils/prometheus.go
+++ b/autopilot-daemon/pkg/utils/prometheus.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
-    "os/exec"
-    "strings"
+	"os/exec"
+	"strings"
 
-    "k8s.io/klog/v2"
-    "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -33,30 +33,30 @@ func InitMetrics(reg prometheus.Registerer) {
 }
 
 func InitHardwareMetrics() {
-    // Define CPUModel global variable
-    cpu := "N/A"
+	// Define CPUModel global variable
+	cpu := "N/A"
 
-    cmd1 := "cat /proc/cpuinfo | egrep '^model name' | uniq | awk '{print substr($0, index($0,$4))}'"
-    out1, err1 := exec.Command("bash","-c",cmd1).Output()
-    if err1 != nil {
-        klog.Info("Error retrieving cpu model info", err1.Error())
-    } else {
-        cpu = string(out1)
-    }
-    klog.Info("CPU_MODEL: ", cpu)
-    CPUModel = cpu
+	cmd := "cat /proc/cpuinfo | egrep '^model name' | uniq | awk '{print substr($0, index($0,$4))}'"
+	out, err := exec.Command("bash", "-c", cmd).Output()
+	if err != nil {
+		klog.Info("Error retrieving cpu model info", err.Error())
+	} else {
+		cpu = strings.TrimSpace(string(out[:]))
+	}
+	klog.Info("CPU_MODEL: ", cpu)
+	CPUModel = cpu
 
-    // Define GPUModel global variable
-    gpu := "N/A"
+	// Define GPUModel global variable
+	gpu := "N/A"
 
-    cmd2 := exec.Command("nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader")
-    out2, err2 := cmd2.CombinedOutput()
-    if err2 != nil {
-        klog.Info("Error retrieving gpu model info", err2.Error())
-    } else {
-        tmp := strings.TrimSpace(string(out2[:]))
-        gpu = strings.Split(tmp, "\n")[0]
-    }
-    klog.Info("GPU_MODEL: ", gpu)
-    GPUModel = gpu
+	cmd2 := exec.Command("nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader")
+	out, err = cmd2.CombinedOutput()
+	if err != nil {
+		klog.Info("Error retrieving gpu model info", err.Error())
+	} else {
+		tmp := strings.TrimSpace(string(out[:]))
+		gpu = strings.Split(tmp, "\n")[0]
+	}
+	klog.Info("GPU_MODEL: ", gpu)
+	GPUModel = gpu
 }


### PR DESCRIPTION
It wasn't possible to filter cpu models on prometheus because of trailing spaces. At least a `\n` was present, but the bug fix removes any whitespace character.

Also, I cleaned the code a bit. 