### PR TITLE
PVC create-delete health check

### DIFF
--- a/alertmanager/alertmanager.yaml
+++ b/alertmanager/alertmanager.yaml
@@ -27,45 +27,13 @@ receivers:
   - name: Critical
   - name: 'null'
   - name: autopilot-pcie
-    slack_configs:
-      - channel: slack-channel-name
-        api_url: >-
-          https://hooks.slack.com/services/...
-        text: 'summary: {{ .CommonAnnotations.summary }}'
-        send_resolved: true
-        username: Autopilot
   - name: autopilot-ping
-    slack_configs:
-      - channel: slack-channel-name
-        api_url: >-
-          https://hooks.slack.com/services/...
-        text: 'summary: {{ .CommonAnnotations.summary }}'
-        send_resolved: true
-        username: Autopilot
   - name: autopilot-remapped
-    slack_configs:
-      - channel: slack-channel-name
-        api_url: >-
-          https://hooks.slack.com/services/...
-        text: 'summary: {{ .CommonAnnotations.summary }}'
-        send_resolved: true
-        username: Autopilot
   - name: autopilot-dcgm
-    slack_configs:
-      - channel: slack-channel-name
-        api_url: >-
-          https://hooks.slack.com/services/...
-        text: 'summary: {{ .CommonAnnotations.summary }}'
-        send_resolved: true
-        username: Autopilot
   - name: autopilot-cordon
-    slack_configs:
-      - channel: slack-channel-name
-        api_url: >-
-          https://hooks.slack.com/services/...
-        text: 'summary: {{ .CommonAnnotations.summary }}'
-        send_resolved: true
-        username: Autopilot
+  - name: autopilot-gpupower
+  - name: autopilot-pvc
+  - name: autopilot-dcgm3
 route:
   group_by:
     - namespace
@@ -95,3 +63,12 @@ route:
     - receiver: autopilot-cordon
       match:
         cordon: autopilot
+    - receiver: autopilot-gpupower
+      match:
+        gpupower: autopilot
+    - receiver: autopilot-pvc
+      match:
+        pvc: autopilot
+    - receiver: autopilot-dcgm3
+      match:
+        dcgm3: autopilot

--- a/alertmanager/alerts/dcgm3-alert.yaml
+++ b/alertmanager/alerts/dcgm3-alert.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dcgm-3-alert
+  namespace: openshift-monitoring
+  labels:
+    cordon: autopilot
+spec:
+  groups:
+  - name: autopilot
+    rules:
+    - alert: DCGM3Alert
+      annotations:
+        description: A node reported errors after running DCGM level 3 - check health of nodes
+        summary: Node {{ $labels.node }} has GPU errors
+      expr: kube_node_labels{label_autopilot_dcgm_level_3=~"ERR.*"}
+      for: 1m
+      labels:
+        severity: critical
+        cordon: autopilot

--- a/alertmanager/alerts/pvc-alert.yaml
+++ b/alertmanager/alerts/pvc-alert.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pvc-alert
+  namespace: openshift-monitoring
+  labels:
+    dcgm: autopilot
+spec:
+  groups:
+  - name: pvc
+    rules:
+    - alert: PVCAlert
+      annotations:
+        description: PVC creation from node node {{ $labels.node }} failed
+        summary: PVC cannot be created
+      expr: sum (autopilot_health_checks{health="pvc"}==1) by (node)
+      for: 1m
+      labels:
+        severity: critical
+        dcgm: autopilot

--- a/alertmanager/alerts/pvc-alert.yaml
+++ b/alertmanager/alerts/pvc-alert.yaml
@@ -11,10 +11,11 @@ spec:
     rules:
     - alert: PVCAlert
       annotations:
-        description: PVC creation from node node {{ $labels.node }} failed
+        description: PVC creation from node {{ $labels.node }} failed
         summary: PVC cannot be created
       expr: sum (autopilot_health_checks{health="pvc"}==1) by (node)
       for: 1m
       labels:
         severity: critical
         dcgm: autopilot
+        

--- a/autopilot-daemon/helm-charts/autopilot/templates/serviceaccount.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/templates/serviceaccount.yaml
@@ -37,6 +37,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
   verbs: ["list", "get"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["list", "get", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/autopilot-daemon/helm-charts/autopilot/values.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/values.yaml
@@ -30,7 +30,7 @@ pullSecrets:
 env:
     - name: "PERIODIC_CHECKS"
       value: "pciebw,remapped,dcgm,ping,gpupower"
-    - name: "STORAGE_CLASS"
+    - name: "PVC_TEST_STORAGE_CLASS"
       value: ""
 
 service:

--- a/autopilot-daemon/helm-charts/autopilot/values.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/values.yaml
@@ -30,6 +30,8 @@ pullSecrets:
 env:
     - name: "PERIODIC_CHECKS"
       value: "pciebw,remapped,dcgm,ping,gpupower"
+    - name: "STORAGE_CLASS"
+      value: ""
 
 service:
   port: 3333

--- a/autopilot-daemon/pkg/handlers/handler.go
+++ b/autopilot-daemon/pkg/handlers/handler.go
@@ -248,3 +248,17 @@ func GpuMemHandler() http.Handler {
 	}
 	return http.HandlerFunc(fn)
 }
+
+func PVCHandler() http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("PVC create-delete test\n"))
+		out, err := runCreateDeletePVC()
+		if err != nil {
+			klog.Error(err.Error())
+		}
+		if out != nil {
+			w.Write(*out)
+		}
+	}
+	return http.HandlerFunc(fn)
+}

--- a/autopilot-daemon/pkg/handlers/healthchecks.go
+++ b/autopilot-daemon/pkg/handlers/healthchecks.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"os/exec"
@@ -378,6 +379,11 @@ func runGPUPower() (*[]byte, error) {
 }
 
 func runCreateDeletePVC() (*[]byte, error) {
+	_, exists := os.LookupEnv("STORAGE_CLASS")
+	if !exists {
+		b := []byte("Storage class not set. Cannot run. ABORT")
+		return &b, errors.New("storage class not set")
+	}
 	err := utils.CreatePVC()
 	if err != nil {
 		klog.Error(err.Error())

--- a/autopilot-daemon/pkg/utils/functions.go
+++ b/autopilot-daemon/pkg/utils/functions.go
@@ -161,7 +161,7 @@ func CreateJob(healthcheck string) {
 
 func CreatePVC() error {
 	cset := GetClientsetInstance()
-	storageclass := os.Getenv("STORAGE_CLASS")
+	storageclass := os.Getenv("PVC_TEST_STORAGE_CLASS")
 	pvcTemplate := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: os.Getenv("POD_NAME"),

--- a/autopilot-daemon/pkg/utils/listwatch.go
+++ b/autopilot-daemon/pkg/utils/listwatch.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	toolswatch "k8s.io/client-go/tools/watch"
+	"k8s.io/klog/v2"
+)
+
+func WatchNode() {
+
+	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+		timeout := int64(60)
+		fieldselector, err := fields.ParseSelector("metadata.name=" + os.Getenv("NODE_NAME"))
+		if err != nil {
+			klog.Info("Error in creating the field selector", err.Error())
+			return nil, err
+		}
+		instance, err := GetClientsetInstance().Cset.CoreV1().Nodes().Watch(context.Background(), metav1.ListOptions{TimeoutSeconds: &timeout, FieldSelector: fieldselector.String()})
+		if err != nil {
+			klog.Info("Error in creating the watcher", err.Error())
+			return nil, err
+		}
+		return instance, err
+	}
+
+	watcher, _ := toolswatch.NewRetryWatcher("1", &cache.ListWatch{WatchFunc: watchFunc})
+
+	for event := range watcher.ResultChan() {
+		item := event.Object.(*corev1.Node)
+
+		switch event.Type {
+		case watch.Modified:
+			{
+				key := "autopilot/dcgm.level.3"
+				labels := item.GetLabels()
+				if val, found := labels[key]; found {
+					var res float64
+					res = 0
+					if strings.Contains(val, "ERR") {
+						res = 1
+						klog.Info("[DCGM level 3] Update observation: ", os.Getenv("NODE_NAME"), " Error found")
+					}
+					HchecksGauge.WithLabelValues("dcgm", os.Getenv("NODE_NAME"), CPUModel, GPUModel, "").Set(res)
+				}
+			}
+		}
+	}
+
+}
+
+func ListPVC() (string, error) {
+	pvc, err := GetClientsetInstance().Cset.CoreV1().PersistentVolumeClaims(os.Getenv("NAMESPACE")).Get(context.Background(), os.Getenv("POD_NAME"), metav1.GetOptions{})
+	if err != nil {
+		klog.Error("Error in creating the lister", err.Error())
+		return "ABORT", err
+	}
+	switch pvc.Status.Phase {
+	case "Bound":
+		{
+			klog.Info("[PVC Create-Delete] PVC Bound: SUCCESS")
+			klog.Info("Observation: ", os.Getenv("NODE_NAME"), " 0")
+			HchecksGauge.WithLabelValues("pvc", os.Getenv("NODE_NAME"), CPUModel, GPUModel, "").Set(0)
+		}
+	case "Pending":
+		{
+			waitonpvc := time.NewTicker(time.Minute)
+			defer waitonpvc.Stop()
+			<-waitonpvc.C
+			pvc, err := GetClientsetInstance().Cset.CoreV1().PersistentVolumeClaims(os.Getenv("NAMESPACE")).Get(context.Background(), os.Getenv("POD_NAME"), metav1.GetOptions{})
+			if err != nil {
+				klog.Error("[PVC Create-Delete] Error in creating the lister: ", err.Error())
+				return "[PVC Create-Delete] PVC not found. ABORT ", err
+			}
+			phase := pvc.Status.Phase
+			if pvc.Status.Phase == "Pending" {
+				klog.Info("[PVC Create-Delete] Timer is up with PVC Pending. Force delete. FAIL")
+				klog.Info("Observation: ", os.Getenv("NODE_NAME"), " 1")
+				HchecksGauge.WithLabelValues("pvc", os.Getenv("NODE_NAME"), CPUModel, GPUModel, "").Set(1)
+				err := DeletePVC(os.Getenv("POD_NAME"))
+				if err != nil {
+					return "[PVC Create-Delete] Error in deleting the PVC. ABORT ", err
+				}
+				return "[PVC Create-Delete] FAIL", nil
+			}
+			if phase == "Bound" {
+				klog.Info("[PVC Create-Delete] PVC Bound: SUCCESS")
+				klog.Info("Observation: ", os.Getenv("NODE_NAME"), " 0")
+				HchecksGauge.WithLabelValues("pvc", os.Getenv("NODE_NAME"), CPUModel, GPUModel, "").Set(0)
+			}
+		}
+	}
+	err = DeletePVC(os.Getenv("POD_NAME"))
+	if err != nil {
+		return "Error in deleting the PVC. ABORT ", err
+	}
+	return "[PVC Create-Delete] PVC SUCCESS", nil
+}

--- a/autopilot-daemon/pkg/utils/prometheus.go
+++ b/autopilot-daemon/pkg/utils/prometheus.go
@@ -23,7 +23,7 @@ var (
 			Name:      "health_checks",
 			Help:      "Summary of the health checks measurements on compute nodes. Gauge Vector version",
 		},
-		[]string{"health", "node", "cpu", "gpu", "deviceid"},
+		[]string{"health", "node", "cpumodel", "gpumodel", "deviceid"},
 	)
 )
 

--- a/autopilot-daemon/utils/runHealthchecks.py
+++ b/autopilot-daemon/utils/runHealthchecks.py
@@ -27,7 +27,7 @@ parser.add_argument('--namespace', type=str, default='autopilot', help='Namespac
 
 parser.add_argument('--nodes', type=str, default='all', help='Node(s) that will run a healthcheck. Can be a comma separated list. Default is \"all\" unless --wkload is provided, then set to None. Specific nodes can be provided in addition to --wkload.')
 
-parser.add_argument('--check', type=str, default='all', help='The specific test(s) that will run: \"all\", \"pciebw\", \"dcgm\", \"remapped\", \"ping\" \"gpumem\" or \"gpupower\". Default is \"all\". Can be a comma separated list.')
+parser.add_argument('--check', type=str, default='all', help='The specific test(s) that will run: \"all\", \"pciebw\", \"dcgm\", \"remapped\", \"ping\", \"gpumem\", \"pvc\" or \"gpupower\". Default is \"all\". Can be a comma separated list.')
 
 parser.add_argument('--batchSize', default='0', type=str, help='Number of nodes to check in parallel. Default is set to the number of the worker nodes.')
 
@@ -164,6 +164,8 @@ def get_node_status(responses):
                     node_status_list.append('PING Failed')
                 elif('GPU-MEM' in line):
                     node_status_list.append("GPU MEM Test Failed")
+                elif('PVC' in line):
+                    node_status_list.append("PVC Create-Delete Test Failed")
                 elif('Disconnected' in line):
                     node_status_list.append('Connection to Server Failed')
 


### PR DESCRIPTION
The PR adds a health check for creation and deletion of PVCs.
The storage class name is passed as environment variable and set in the values for the helm chart.

If added to the periodic check through `pvc`, it creates a pvc and deletes it if it's bound or after a time out if pending.

Also this PR adds some extra alerts in the alertmanager.