### PR TITLE
bugfix: ping test

### DIFF
--- a/autopilot-daemon/network/ping-entrypoint.py
+++ b/autopilot-daemon/network/ping-entrypoint.py
@@ -140,8 +140,8 @@ def check_local_ifaces():
         ips.append(entry['ips'])
     ifaces = netifaces.interfaces()
     ifaces.remove('lo')
-    ifaces.remove('eth0')
-    if len(ips) > 0 and len(ifaces) == 0 :
+
+    if len(ips) != len(ifaces) :
         print("[PING] IFACES count inconsistent. Pod annotation reports", ips, ", not found in the pod among", netifaces.interfaces(),"ABORT")
         exit()
 

--- a/autopilot-daemon/pkg/handlers/healthchecks.go
+++ b/autopilot-daemon/pkg/handlers/healthchecks.go
@@ -244,6 +244,17 @@ func runPing(nodelist string, jobName string, nodelabel string) (*[]byte, error)
 		klog.Error(err.Error())
 		return nil, err
 	} else {
+		klog.Info("Ping test completed:")
+
+		if strings.Contains(string(out[:]), "FAIL") {
+			klog.Info("Ping test failed.", string(out[:]))
+		}
+
+		if strings.Contains(string(out[:]), "ABORT") {
+			klog.Info("Ping cannot be run. ", string(out[:]))
+			return &out, nil
+		}
+
 		output := strings.TrimSuffix(string(out[:]), "\n")
 		lines := strings.Split(output, "\n")
 		unreach_nodes := make(map[string][]string)


### PR DESCRIPTION
This PR fixes two bugs in the ping test

1. The ABORT message wasn't being parsed, and the test would report success with consequent success export to Prometheus
2. The count of the interfaces done to check if there were issues with multi-nic assigning the secondary interfaces, wasn't taking into account that having `eth0` only is a valid deployment of the daemonset