### PR TITLE
Enabling GPU-less Autopilot

### DIFF
--- a/autopilot-daemon/helm-charts/autopilot/templates/autopilot.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/templates/autopilot.yaml
@@ -25,7 +25,7 @@ spec:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end}}
       {{- if .Values.onlyOnGPUNodes }}
-        - nvidia.com/gpu.present: 'true'
+        nvidia.com/gpu.present: 'true'
       {{- end}}
       serviceAccountName: autopilot
       {{- if .Values.pullSecrets.create }}

--- a/autopilot-daemon/helm-charts/autopilot/templates/autopilot.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/templates/autopilot.yaml
@@ -20,14 +20,19 @@ spec:
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}
       {{- end}}
-      {{- if .Values.nodeSelector }}
       nodeSelector:
+      {{- if .Values.nodeSelector }}
       {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end}}
+      {{- if .Values.onlyOnGPUNodes }}
+        - nvidia.com/gpu.present: 'true'
+      {{- end}}
       serviceAccountName: autopilot
+      {{- if .Values.pullSecrets.create }}
       imagePullSecrets:
       - name: {{ .Values.pullSecrets.name }}
-      {{- if .Values.gpuEnabled }}
+      {{- end}}
+      {{- if .Values.onlyOnGPUNodes }}
       initContainers:
         - args:
           - until [ -f /usr/bin/nvidia-smi ]; do echo waiting for nvidia device plug-in to be setup; sleep 5 && exit -1; done

--- a/autopilot-daemon/helm-charts/autopilot/values.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/values.yaml
@@ -17,7 +17,7 @@ PCIeBW: 4
 # Timer for periodic checks, in hours
 repeat: 1
 
-# Timer for periodic invasive checks, in hours (e.g., dcgmi diag -r 3)
+# Timer for periodic invasive checks, in hours (e.g., dcgmi diag -r 3). Set to 0 to disable (for non nvidia gpu systems)
 intrusive: 4
 
 # Image pull secret if the image is in a private repository
@@ -26,7 +26,8 @@ pullSecrets:
   name: autopilot-pull-secret
   imagePullSecretData: 
   
-# List of periodic checks to be executed every `repeat` hours
+# List of periodic checks to be executed every `repeat` hours.
+# If not running on GPU nodes, pciebw,remapped,dcgm and gpupower can be removed
 env:
   - name: "PERIODIC_CHECKS"
     value: "pciebw,remapped,dcgm,ping,gpupower"
@@ -40,12 +41,15 @@ annotations:
   # k8s.v1.cni.cncf.io/networks: multi-nic-network
 
 nodeSelector:
-  nvidia.com/gpu.present: 'true'
+  # nvidia.com/gpu.present: 'true'
   # nvidia.com/mig.config: 'all-disabled'
 
 affinity:
 
-gpuEnabled: true
+# Running on GPU nodes only, will:
+# 1) add the `nvidia.com/gpu.present: 'true'` label and 
+# 2) enable the init container, which checks on the nvidia device plug-in to be setup
+onlyOnGPUNodes: true
 
 resources: 
   # We advice to not set cpu and memory limits. DCGM requires several GB of memory to run and it may OOMKill the pod
@@ -53,13 +57,6 @@ resources:
     nvidia.com/gpu: 0
   requests:
     nvidia.com/gpu: 0
-
-# serviceAnnotations:
-#    service.beta.openshift.io/serving-cert-secret-name: autopilot
-
-
-# configAnnotations: 
-#   service.beta.openshift.io/inject-cabundle: "true"
 
 # klog configuration
 loglevel: 2


### PR DESCRIPTION
This PR enables a better deployment of autopilot on gpu-less or heterogeneous clusters (gpu and cpu nodes in the same cluster) and it adds a better check on the existence of gpus  before trying to create the external job (dcgm level 3 diagnostics).

The majority of the changes are in the helm charts and values.
The main goal is to enable the init container if and only if autopilot will run only on gpu nodes.