### PR TITLE
Node Labeling for General GPU Health

### DIFF
--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -224,7 +224,7 @@ def patch_node(success, output):
     label = {
         "metadata": {
             "labels": {
-                "autopilot/dcgm.level.3": result}
+                "autopilot.ibm.com/dcgm.level.3": result}
         }
     }
     print("label: ", result)

--- a/autopilot-daemon/pkg/utils/functions.go
+++ b/autopilot-daemon/pkg/utils/functions.go
@@ -11,7 +11,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -49,31 +51,36 @@ func GetPeriodicChecks() string {
 	return checks
 }
 
-// Returns true if GPUs are not currently requested by any workload
-func GPUsAvailability() bool {
+func GetNode(nodename string) (*corev1.Node, error) {
 	cset := GetClientsetInstance()
-	fieldselector, err := fields.ParseSelector("metadata.name=" + os.Getenv("NODE_NAME"))
+	fieldselector, err := fields.ParseSelector("metadata.name=" + nodename)
 	if err != nil {
 		klog.Info("Error in creating the field selector ", err.Error())
-		return false
+		return nil, err
 	}
 	instance, err := cset.Cset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{FieldSelector: fieldselector.String()})
 	if err != nil {
 		klog.Info("Error in creating the watcher ", err.Error())
-		return false
+		return nil, err
 	}
+	return &instance.Items[0], nil
+}
 
-	nodelabels := instance.Items[0].Labels
+// Returns true if GPUs are not currently requested by any workload
+func GPUsAvailability() bool {
+	node, _ := GetNode(os.Getenv("NODE_NAME"))
+	nodelabels := node.Labels
 	if _, found := nodelabels["nvidia.com/gpu.present"]; !found {
 		klog.Info("GPUs not found on node ", os.Getenv("NODE_NAME"), ". Cannot run invasive health checks.")
 		return false
 	}
 	// Once cleared, list pods using gpus and abort the check if gpus are in use
-	fieldselector, err = fields.ParseSelector("spec.nodeName=" + os.Getenv("NODE_NAME") + ",status.phase!=" + string(corev1.PodSucceeded))
+	fieldselector, err := fields.ParseSelector("spec.nodeName=" + os.Getenv("NODE_NAME") + ",status.phase!=" + string(corev1.PodSucceeded))
 	if err != nil {
 		klog.Info("Error in creating the field selector ", err.Error())
 		return false
 	}
+	cset := GetClientsetInstance()
 	pods, err := cset.Cset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
 		FieldSelector: fieldselector.String(),
 	})
@@ -219,4 +226,14 @@ func DeletePVC(pvc string) error {
 		klog.Info("[PVC Delete] Failed. ABORT. ", err.Error())
 	}
 	return err
+}
+
+func PatchNode(label string, nodename string) error {
+	cset := GetClientsetInstance()
+	_, err := cset.Cset.CoreV1().Nodes().Patch(context.TODO(), nodename, types.StrategicMergePatchType, []byte(label), v1.PatchOptions{})
+	if err != nil {
+		klog.Info("[Node Patch] Failed. ", err.Error())
+		return err
+	}
+	return nil
 }

--- a/autopilot-daemon/pkg/utils/listwatch.go
+++ b/autopilot-daemon/pkg/utils/listwatch.go
@@ -40,7 +40,7 @@ func WatchNode() {
 		switch event.Type {
 		case watch.Modified:
 			{
-				key := "autopilot/dcgm.level.3"
+				key := "autopilot.ibm.com/dcgm.level.3"
 				labels := item.GetLabels()
 				if val, found := labels[key]; found {
 					var res float64


### PR DESCRIPTION
This PR adds (or updates) a label to the nodes every time there's a periodic or manual health check on GPUs.
The label is particularly useful for appwrappers when deciding which node to avoid when scheduling a job.

The PR also updates the name of the dcgm label with `autopilot.ibm.com` key.

Also, some updates to the README are provided.