### PR TITLE
Node label add and ping gauge update

### DIFF
--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -216,15 +216,18 @@ def patch_node(success, output):
     now = datetime.datetime.now(datetime.timezone.utc)
     timestamp = now.strftime("%Y-%m-%d_%H.%M.%SUTC")
     result = ""
+    general_health = "PASS"
     if success:
         result = "PASS_"+timestamp
     else:
         result = "ERR_"+timestamp+"_"+output
+        general_health = "EVICT"
 
     label = {
         "metadata": {
             "labels": {
-                "autopilot.ibm.com/dcgm.level.3": result}
+                "autopilot.ibm.com/dcgm.level.3": result,
+                "autopilot.ibm.com/gpuhealth": general_health}
         }
     }
     print("label: ", result)

--- a/autopilot-daemon/pkg/handlers/healthchecks.go
+++ b/autopilot-daemon/pkg/handlers/healthchecks.go
@@ -303,11 +303,11 @@ func runPing(nodelist string, jobName string, nodelabel string) (*[]byte, error)
 			if strings.HasPrefix(line, "Node") {
 				entry := strings.Split(line, " ")
 				if entry[len(entry)-1] == "1" {
-					utils.HchecksGauge.WithLabelValues("ping", entry[1], utils.CPUModel, utils.GPUModel, entry[2]).Set(1)
+					utils.HchecksGauge.WithLabelValues("ping", os.Getenv("NODE_NAME"), utils.CPUModel, utils.GPUModel, entry[1]).Set(1)
 					klog.Info("Observation: ", entry[1], " ", entry[2], " ", entry[3], " Unreachable")
 					unreach_nodes[entry[1]] = append(unreach_nodes[entry[1]], entry[2])
 				} else {
-					utils.HchecksGauge.WithLabelValues("ping", entry[1], utils.CPUModel, utils.GPUModel, entry[2]).Set(0)
+					utils.HchecksGauge.WithLabelValues("ping", os.Getenv("NODE_NAME"), utils.CPUModel, utils.GPUModel, entry[1]).Set(0)
 				}
 			}
 		}


### PR DESCRIPTION
This PR addresses two things

1. Addition of an `EVICT` node label, which is added only if the invasive `dcgm diag -r 3` test reports failures in the GPUs. This is always part of the interactions with CodeFlare for [fault tolerance and self recovery ](https://project-codeflare.github.io/appwrapper/arch-fault-tolerance/)
2. Changes to the data passed to the Prometheus gauge for the ping test. At the beginning, we were reporting the IP of the NIC that wasn't reachable. This has the problem that, if the unhealthy pod is restarted, that IP address is no longer valid. The consequence is that we'll have that entry in Prometheus until the data is obsolete and deleted, and even thought the ping issue is resolved, the faulty IP entry is going to be reported anyways.
The proposed change is a switch from the IP to the node name, so if the problem is resolved, the entry will disappear. 