### PR TITLE
Add probes for liveness and readiness

### DIFF
--- a/autopilot-daemon/helm-charts/autopilot/Chart.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: autopilot-daemon
+name: autopilot
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/autopilot-daemon/helm-charts/autopilot/templates/autopilot.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/templates/autopilot.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   labels:
     app: autopilot
-  name: {{ printf "%s-%s" .Chart.Name .Release.Name }}
+  name: {{ printf "%s" .Chart.Name }}
   namespace: {{ .Values.namespace.name }}
 spec:
   selector:
@@ -56,7 +56,7 @@ spec:
            - -c
            - |
              iperf3 -s -p 6310 -D 
-             /usr/local/bin/autopilot --port {{ .Values.service.port }} --loglevel={{ .Values.loglevel }} --bw {{ .Values.PCIeBW }} --w {{ .Values.repeat }} --intrusive-check-timer {{ .Values.intrusive }}
+             /usr/local/bin/autopilot --port {{ .Values.service.port }} --loglevel={{ .Values.loglevel }} --bw {{ .Values.PCIeBW }} --w {{ .Values.repeat }} --invasive-check-timer {{ .Values.invasive }}
           imagePullPolicy: {{ .Values.image.pullPolicy }} 
           name: autopilot
           securityContext:
@@ -87,6 +87,28 @@ spec:
               name: healthcheck
             - containerPort: 8081
               name: http
+            - containerPort: 8080
+              name: readinessprobe
+          readinessProbe:
+            httpGet:
+              path: /readinessprobe
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 120
+            timeoutSeconds: 10
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 120
+            timeoutSeconds: 15
+          {{- if .Values.onlyOnGPUNodes }}
+            exec:
+              command:
+                - nvidia-smi
+          {{- else }}
+            httpGet:
+              path: /readinessprobe
+              port: 8080
+          {{- end}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/autopilot-daemon/helm-charts/autopilot/templates/service.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/templates/service.yaml
@@ -8,10 +8,24 @@ metadata:
   annotations: 
     {{- toYaml .Values.serviceAnnotations | nindent 4 }}
 spec:
-  # type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       protocol: TCP
       name: healthcheck
+  selector:
+    app: autopilot
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autopilot
+  name: autopilot-readinessprobe
+  namespace: {{ .Values.namespace.name }}
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP 
+      name: readinessprobe
   selector:
     app: autopilot

--- a/autopilot-daemon/helm-charts/autopilot/values.yaml
+++ b/autopilot-daemon/helm-charts/autopilot/values.yaml
@@ -18,7 +18,7 @@ PCIeBW: 4
 repeat: 1
 
 # Timer for periodic invasive checks, in hours (e.g., dcgmi diag -r 3). Set to 0 to disable (for non nvidia gpu systems)
-intrusive: 4
+invasive: 4
 
 # Image pull secret if the image is in a private repository
 pullSecrets:

--- a/autopilot-daemon/pkg/handlers/handler.go
+++ b/autopilot-daemon/pkg/handlers/handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
@@ -259,6 +260,16 @@ func PVCHandler() http.Handler {
 		if out != nil {
 			w.Write(*out)
 		}
+	}
+	return http.HandlerFunc(fn)
+}
+
+func ReadinessProbeHandler() http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		data := HealthResult{"readinessProbe", "ready"}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(data)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/autopilot-daemon/pkg/handlers/healthchecks.go
+++ b/autopilot-daemon/pkg/handlers/healthchecks.go
@@ -21,7 +21,7 @@ func PeriodicCheckTimer() {
 	runAllTestsLocal("all", checks, "1", "None", "None", nil)
 }
 
-func IntrusiveCheckTimer() {
+func InvasiveCheckTimer() {
 	klog.Info("Trying to run an intrusive check")
 	utils.HealthcheckLock.Lock()
 	defer utils.HealthcheckLock.Unlock()

--- a/autopilot-daemon/pkg/handlers/messagestruct.go
+++ b/autopilot-daemon/pkg/handlers/messagestruct.go
@@ -1,0 +1,6 @@
+package handlers
+
+type HealthResult struct {
+	Name string
+	Body string
+}


### PR DESCRIPTION
This PR introduces liveness and readiness probes, plus some updates to the helm charts.

- rename the daemonset name to `autopilot` instead of `autopilot-daemon-autopilot`
- rename of the variable name for the invasive check. It was called intrusive but we always refer to it as invasive
- readiness probe with HTTP endpoint. This endpoint `/readinessprobe` is associated to a Service on port 8080 that can be reached out manually for smoketests and such
- first attempt at using json as response, starting with the readiness probe API. It's an extremely minimal message struct, but it's generic enough to start with.

