### PR TITLE
Fix issue #49: Updated command in Step 2 of Install section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ helm repo add autopilot git+https://github.com/IBM/autopilot.git@autopilot-daemo
 2) Install autopilot (idempotent command). The config file is for customizing the helm values. Namespace is where the helm chart will live, not the namespace where Autopilot runs
 
 ```bash
-helm upgrade autopilot autopilot/autopilot-daemon --install --namespace=<default> -f your-config.yml
+helm upgrade autopilot autopilot/autopilot --install --namespace=<default> -f your-config.yml
 ```
 
 The controllers should show up in the selected namespace


### PR DESCRIPTION
Changed command in Step 2 of Install section in README to: 
helm upgrade autopilot autopilot/autopilot --install --namespace=<default> -f your-config.yml

# Summary

Step 2 of the Install section on the README instructs users to use the following command to install Autopilot:
`helm upgrade autopilot autopilot/autopilot-daemon --install --namespace=<default> -f your-config.yml`
However, this command is outdated as the helm chart name is autopilot, not autopilot-daemon. This PR fixes this and changes to the correct command which is:
`helm upgrade autopilot autopilot/autopilot --install --namespace=<default> -f your-config.yml`

## GitHub Issue
- [#49 - [Bug] Error in Step 2 of Install section in README](https://github.com/IBM/autopilot/issues/49)
