### PR TITLE
Address Documentation Issue #57: Include clarification on selecting multiple node selection parameters in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -39,6 +39,8 @@ All tests can be tailored by a combination of:
 - `batch=<#hosts>`, how many hosts to check at a single moment. Requests to the batch are run in parallel asynchronously. Batching is done to avoid running too many requests in parallel when the number of worker nodes increases. Defaults to all nodes.
 
 Some health checks provide further customization. More details on all the tests can be found [here](https://github.com/IBM/autopilot/autopilot-daemon/HEALTH_CHECKS.md)
+Note that if multiple node selection parameters (`host`, `job`, `nodelabel`) are provided together, Autopilot will run tests on nodes that match _any_  of the specified parameters (set union). For example, the following command will run the `pciebw` test on all nodes that either have the label `label1` OR are running the job `jobKey=job2` because both `nodelabel` and `job` parameters are provided in the input:
+`curl "http://<route-name>/status?check=pciebw&nodelabel=label1&job=default:jobKey=job2"`
 
 ## DCGM
 


### PR DESCRIPTION
# Summary

USAGE.md mentions how tests can be configured using a combination of parameters. The host, job, and nodelabel parameters all involve node selection. To clarify behavior when multiple node selection parameters are used together, I mentioned that Autopilot runs the tests on nodes that match any of the specified parameters (set union rather than set intersection).

I specifically added the following sentences under the parameters list in USAGE.md:
Note that if multiple node selection parameters (`host`, `job`, `nodelabel`) are provided together, Autopilot will run tests on nodes that match _any_  of the specified parameters (set union). For example, the following command will run the `pciebw` test on all nodes that either have the label `label1` OR are running the job `jobKey=job2` because both `nodelabel` and `job` parameters are provided in the input:
`curl "http://<route-name>/status?check=pciebw&nodelabel=label1&job=default:jobKey=job2"`

## GitHub Issue

- [#57 - [Documentation] Clarification on node selection parameters in USAGE.md](https://github.com/IBM/autopilot/issues/57)