### PR TITLE
[Enhancement] Default Arguments for iperf3 Test

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -58,8 +58,14 @@ As part of this workload, Autopilot will generate the Ring Workload and then sta
 # Invoked via the `status` handle:
 curl "http://autopilot-healthchecks-autopilot.<domain>/status?check=iperf&workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
 
+# Invoked via the `status` with defaults (iperf clients = 8, starting server port = 5200, workload = ring):
+curl "http://autopilot-healthchecks-autopilot.<domain>/status?check=iperf"
+
 # Invoked via the `iperf` handle directly:
 curl "http://autopilot-healthchecks-autopilot.<domain>/iperf?workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
+
+# Invoked via the `iperf` handle directly (iperf clients = 8, starting server port = 5200, workload = ring):
+curl "http://autopilot-healthchecks-autopilot.<domain>/iperf"
 ```
 
 ## Concrete Example

--- a/USAGE.md
+++ b/USAGE.md
@@ -62,16 +62,16 @@ As part of this workload, Autopilot will generate the Ring Workload and then sta
 
 ```bash
 # Invoked via the `status` handle:
-curl "http://autopilot-healthchecks-autopilot.<domain>/status?check=iperf&workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
+curl "http://127.0.0.1:3333/status?check=iperf&workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
 
 # Invoked via the `status` with defaults (iperf clients = 8, starting server port = 5200, workload = ring):
-curl "http://autopilot-healthchecks-autopilot.<domain>/status?check=iperf"
+curl "http://127.0.0.1:3333/status?check=iperf"
 
 # Invoked via the `iperf` handle directly:
-curl "http://autopilot-healthchecks-autopilot.<domain>/iperf?workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
+curl "http://127.0.0.1:3333/iperf?workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
 
 # Invoked via the `iperf` handle directly (iperf clients = 8, starting server port = 5200, workload = ring):
-curl "http://autopilot-healthchecks-autopilot.<domain>/iperf"
+curl "http://127.0.0.1:3333/iperf"
 ```
 
 ## Concrete Example

--- a/autopilot-daemon/network/README.md
+++ b/autopilot-daemon/network/README.md
@@ -48,8 +48,8 @@ Invocation from the exposed Autopilot API is as follows below:
 
 ```bash
     # Invoked via the `status` handle:
-curl "http://autopilot-healthchecks-autopilot.<domain>/status?check=iperf&workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
+curl "http://127.0.0.1:3333/status?check=iperf&workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
 
     # Invoked via the `iperf` handle directly:
-curl "http://autopilot-healthchecks-autopilot.<domain>/iperf?workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
+curl "http://127.0.0.1:3333/iperf?workload=ring&pclients=<NUMBER_OF_IPERF3_CLIENTS>&startport=<STARTING_IPERF3_SERVER_PORT>"
 ```

--- a/autopilot-daemon/pkg/handlers/handler.go
+++ b/autopilot-daemon/pkg/handlers/handler.go
@@ -66,8 +66,8 @@ func SystemStatusHandler() http.Handler {
 		}
 		if checks != "" {
 			if hosts == os.Getenv("NODE_NAME") {
-				klog.Info("Checking system status of host " + hosts + " (localhost)")
-				w.Write([]byte("Checking system status of host " + hosts + " (localhost) \n\n"))
+				klog.Info("Running iperf3 on all hosts")
+				w.Write([]byte("Running iperf3 on all hosts\n\n"))
 				utils.HealthcheckLock.Lock()
 				defer utils.HealthcheckLock.Unlock()
 				out, err := runAllTestsLocal(hosts, checks, dcgmR, jobName, nodelabel, r)

--- a/autopilot-daemon/pkg/handlers/handler.go
+++ b/autopilot-daemon/pkg/handlers/handler.go
@@ -41,8 +41,17 @@ func SystemStatusHandler() http.Handler {
 			w.Write([]byte("Running iperf3 on hosts " + hosts + " or job " + jobName + "\n\n"))
 			checks = strings.Trim(checks, "iperf")
 			workload := r.URL.Query().Get("workload")
+			if workload == "" {
+				workload = "ring"
+			}
 			pclients := r.URL.Query().Get("pclients")
+			if pclients == "" {
+				pclients = "8"
+			}
 			startport := r.URL.Query().Get("startport")
+			if startport == "" {
+				startport = "5200"
+			}
 			cleanup := ""
 			if r.URL.Query().Has("cleanup") {
 				cleanup = "--cleanup"
@@ -149,8 +158,17 @@ func IperfHandler() http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		
 		workload := r.URL.Query().Get("workload")
+		if workload == "" {
+			workload = "ring"
+		}
 		pclients := r.URL.Query().Get("pclients")
+		if pclients == "" {
+			pclients = "8"
+		}
 		startport := r.URL.Query().Get("startport")
+		if startport == "" {
+			startport = "5200"
+		}
 		cleanup := ""
 		if r.URL.Query().Has("cleanup") {
 			cleanup = "--cleanup"
@@ -169,7 +187,13 @@ func IperfHandler() http.Handler {
 func StartIperfServersHandler() http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		numservers := r.URL.Query().Get("numservers")
+		if numservers == "" {
+			numservers = "8"
+		}
 		startport := r.URL.Query().Get("startport")
+		if startport == "" {
+			startport = "5200"
+		}
 		out, err := startIperfServers(numservers, startport)
 
 		if err != nil {

--- a/autopilot-daemon/pkg/handlers/healthchecks.go
+++ b/autopilot-daemon/pkg/handlers/healthchecks.go
@@ -344,11 +344,6 @@ func runPing(nodelist string, jobName string, nodelabel string) (*[]byte, error)
 
 func runIperf(workload string, pclients string, startport string, cleanup string) (*[]byte, error) {
 
-	if workload == "" || pclients == "" || startport == "" {
-		klog.Error("Must provide arguments \"workload\", \"pclients\" and \"startport\".")
-		return nil, nil
-	}
-
 	args := []string{"./network/iperf3_entrypoint.py", "--workload", workload, "--pclients", pclients, "--startport", startport}
 
 	if cleanup != "" {
@@ -363,10 +358,6 @@ func runIperf(workload string, pclients string, startport string, cleanup string
 }
 
 func startIperfServers(numservers string, startport string) (*[]byte, error) {
-	if numservers == "" || startport == "" {
-		klog.Error("Must provide arguments \"numservers\" and \"startport\".")
-		return nil, nil
-	}
 	out, err := exec.Command("python3", "./network/iperf3_start_servers.py", "--numservers", numservers, "--startport", startport).CombinedOutput()
 	if err != nil {
 		klog.Info(string(out))


### PR DESCRIPTION
<!-- 

-=-=-=-= Replace the itallic content with your own. -=-=-=-=
-=-=-=-=  Don't forget to update the GitHub Issue   -=-=-=-=
-=-=-=-=      your Pull-Request pertains to!        -=-=-=-=

 -->

# Summary

- Adds default options from `go` side of autopilot for `iperf3` workload tests.

## Scope and Impact

- No breaking changes, just simplicity.

## GitHub Issue
- None.

## How was this Pull-Request Tested and Validated?

- Tested on an internal cluster.

## Pull-Request Reminders

- Does the [Autopilot Readme](https://github.com/IBM/autopilot?tab=readme-ov-file#ai-training-autopilot) require updates?
  - No

- Are there any new software dependencies introduced to this Pull-Request?
  - No
