### PR TITLE
DCGM label report fix and other minor improvements

### DIFF
--- a/alertmanager/alerts/healthchecks-alerts.yaml
+++ b/alertmanager/alerts/healthchecks-alerts.yaml
@@ -20,10 +20,10 @@ spec:
       labels:
         severity: warning
         alert: autopilot
-    - alert: AutopilotDCGMLevel1Errors
+    - alert: AutopilotDCGMErrors
       annotations:
         description: |
-          GPUs on node {{ $labels.node }} have DCGM Level 1 failures{{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+          GPUs on node {{ $labels.node }} have DCGM failures{{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
         summary: GPUs have DCGM failures
       expr: |
         sum (autopilot_health_checks{health="dcgm"}==1) by (node)
@@ -59,7 +59,7 @@ spec:
           A node reported errors after running DCGM level 3 - check health of nodes{{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
         summary: Node {{ $labels.node }} has GPU errors
       expr: |  
-        kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~".*page_retirement_row_remap.*"}
+        kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*EVICT.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""}
       for: 5m
       labels:
         severity: critical

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -14,6 +14,7 @@ nodename = os.getenv("NODE_NAME")
 parser = argparse.ArgumentParser()
 parser.add_argument('-r', '--run', type=str, default='1')
 parser.add_argument('-l', '--label_node', action='store_true')
+parser.add_argument('-v', '--verbose', action='store_true')
 args = parser.parse_args()
 
 def main():
@@ -202,6 +203,8 @@ def try_dcgm(command):
        print("[[ DCGM ]] exited with error: " + result.stderr + " ERR")
     else:
         testpaths = os.getenv("AUTOPILOT_DCGM_RESULT_PATHS")
+        if args.verbose:
+            print(result.stdout)
         if testpaths == None:
             success, output = parse_all_results(result.stdout)
         if success:

--- a/autopilot-daemon/pkg/cmd/main.go
+++ b/autopilot-daemon/pkg/cmd/main.go
@@ -119,7 +119,7 @@ func main() {
 		}
 	}()
 
-	// Create a Watcher over nodes. Needed to export metrics from data created by external jobs (i.e., dcgm Jobs or PytorchJob NCCL tests)
+	// Create a Watcher over nodes. Needed to export metrics from data created by external jobs (i.e., dcgm Jobs)
 	go utils.WatchNode()
 
 	// Run the health checks at startup, then start the timer

--- a/autopilot-daemon/pkg/handler/handler.go
+++ b/autopilot-daemon/pkg/handler/handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 
@@ -67,7 +66,7 @@ func SystemStatusHandler() http.Handler {
 			}
 		}
 		if checks != "" {
-			if hosts == os.Getenv("NODE_NAME") {
+			if hosts == utils.NodeName {
 				utils.HealthcheckLock.Lock()
 				defer utils.HealthcheckLock.Unlock()
 				out, err := healthcheck.RunHealthLocalNode(checks, dcgmR, jobName, nodelabel, r)

--- a/autopilot-daemon/pkg/healthcheck/healthcheck.go
+++ b/autopilot-daemon/pkg/healthcheck/healthcheck.go
@@ -139,7 +139,7 @@ func RunHealthLocalNode(checks string, dcgmR string, jobName string, nodelabel s
 func RunHealthRemoteNodes(host string, check string, batch string, jobName string, dcgmR string, nodelabel string) (*[]byte, error) {
 	klog.Info("About to run command:\n", "./utils/runHealthchecks.py", " --nodes="+host, " --check="+check, " --batchSize="+batch, " --wkload="+jobName, " --dcgmR="+dcgmR, " --nodelabel="+nodelabel)
 
-	out, err := exec.Command("python3", "./utils/runHealthchecks.py", "--service=autopilot-healthchecks", "--namespace="+os.Getenv("NAMESPACE"), "--nodes="+host, "--check="+check, "--batchSize="+batch, "--wkload="+jobName, "--dcgmR="+dcgmR, "--nodelabel="+nodelabel).Output()
+	out, err := exec.Command("python3", "./utils/runHealthchecks.py", "--service=autopilot-healthchecks", "--namespace="+utils.Namespace, "--nodes="+host, "--check="+check, "--batchSize="+batch, "--wkload="+jobName, "--dcgmR="+dcgmR, "--nodelabel="+nodelabel).Output()
 	if err != nil {
 		klog.Info(string(out))
 		klog.Error(err.Error())

--- a/autopilot-daemon/pkg/utils/global.go
+++ b/autopilot-daemon/pkg/utils/global.go
@@ -26,3 +26,5 @@ var CPUModel string
 var GPUModel string
 
 var NodeName string = os.Getenv("NODE_NAME")
+var Namespace string = os.Getenv("NAMESPACE")
+var PodName string = os.Getenv("POD_NAME")

--- a/autopilot-daemon/pkg/utils/listwatch.go
+++ b/autopilot-daemon/pkg/utils/listwatch.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,10 +14,9 @@ import (
 )
 
 func WatchNode() {
-
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		timeout := int64(60)
-		fieldselector, err := fields.ParseSelector("metadata.name=" + os.Getenv("NODE_NAME"))
+		fieldselector, err := fields.ParseSelector("metadata.name=" + NodeName)
 		if err != nil {
 			klog.Info("Error in creating the field selector", err.Error())
 			return nil, err
@@ -44,11 +42,11 @@ func WatchNode() {
 				if val, found := labels[key]; found {
 					var res float64
 					res = 0
-					if strings.Contains(val, "ERR") {
+					if strings.Contains(val, "EVICT") {
 						res = 1
-						klog.Info("[DCGM level 3] Update observation: ", os.Getenv("NODE_NAME"), " Error found")
+						klog.Info("[DCGM level 3] Update observation: ", NodeName, " Fatal error found")
 					}
-					HchecksGauge.WithLabelValues("dcgm", os.Getenv("NODE_NAME"), CPUModel, GPUModel, "").Set(res)
+					HchecksGauge.WithLabelValues("dcgm", NodeName, CPUModel, GPUModel, "").Set(res)
 				}
 			}
 		}

--- a/helm-charts/autopilot/Chart.yaml
+++ b/helm-charts/autopilot/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2.1.1
+version: v2.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/autopilot/templates/autopilot.yaml
+++ b/helm-charts/autopilot/templates/autopilot.yaml
@@ -64,7 +64,7 @@ spec:
           env:
           {{- range .Values.env }}
             - name: {{ .name }}
-              value: {{ .value }}
+              value: {{ .value | quote}}
           {{- end }} 
             - name: "NODE_NAME"
               valueFrom:

--- a/helm-charts/autopilot/values.yaml
+++ b/helm-charts/autopilot/values.yaml
@@ -31,6 +31,9 @@ env:
 # List of GPU errors considered fatal, as a result of a dcgmi run. This is used to label nodes with extra WARN/EVICT labels. The list defaults to [PCIe,NVLink,ECC,GPU Memory] and refers to https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/feature-overview.html#id3
   - name: "DCGM_FATAL_ERRORS"
     value: ""
+# Invasive jobs (e.g., dcgm level 3), are executed as separate job. The job deletes itself by default after 30s. This parameter can be customized by the env variable below
+  - name: "INVASIVE_JOB_TTLSEC"
+    value: ""
 
 service:
   port: 3333


### PR DESCRIPTION
<!-- 

-=-=-=-= Replace the italic content with your own. -=-=-=-=
-=-=-=-=  Don't forget to update the GitHub Issue   -=-=-=-=
-=-=-=-=      your Pull-Request pertains to!        -=-=-=-=

 -->

# Summary

This PR:
- fixes missed prometheus metrics when `EVICT` label is added to a node
- adds a custom TTL for dcgm invasive jobs for later logs analysis 
- adds a `verbose` parameter in dcgm, that's used in the invasive jobs to print the output. The output is otherwise saved in memory by python and parsed
- minor code and alerts improvements

## Scope and Impact

- _API Changes?_
- No

## GitHub Issue
- None

## How was this Pull-Request Tested and Validated?

- Left running for a week and manually injected errors

## Pull-Request Reminders

- Does the [Autopilot Readme](https://github.com/IBM/autopilot?tab=readme-ov-file#ai-training-autopilot) require updates?
  - No

- Are there any new software dependencies introduced to this Pull-Request?
  - No
