### PR TITLE
Dcgm run 3 fix

### DIFF
--- a/HEALTH_CHECKS.md
+++ b/HEALTH_CHECKS.md
@@ -70,10 +70,13 @@ autopilot.ibm.com/gpuhealth: EVICT
 
 Only fatal errors should produce an `EVICT` label. We follow [NVIDIA recommendations](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/feature-overview.html#id3), although it is possible to customize the list of tests through the Helm chart. The default values are `[PCIe,NVLink,ECC,GPU Memory]`.
 
-If errors are found during the level 3 diagnostics, the label `autopilot.ibm.com/dcgm.level.3` will contain detailed information about the error in the following format:
+If errors are found during the level 3 diagnostics, the label `autopilot.ibm.com/dcgm.level.3` will contain the result and timestamp related to the latest run, while the annotation `autopilot.ibm.com/dcgm.level.3.output` will contain detailed information about the error in the following format:
 
 ```yaml
-autopilot.ibm.com/dcgm.level.3: ERR_Year-Month-Date_Hour.Minute.UTC_Diagnostic_Test.gpuID,Diagnostic_Test.gpuID,...`
+labels:
+    autopilot.ibm.com/dcgm.level.3: ERR_Year-Month-Date_Hour.Minute.UTC
+annotations:
+    autopilot.ibm.com/dcgm.level.3.output: Diagnostic_Test.gpuID,Diagnostic_Test.gpuID,...`
 ```
 
 - `ERR`: An indicator that an error has occurred
@@ -81,9 +84,16 @@ autopilot.ibm.com/dcgm.level.3: ERR_Year-Month-Date_Hour.Minute.UTC_Diagnostic_T
 - `Diagnostic_Test`: Name of the test that has failed (formatted to replace spaces with underscores)
 - `gpuID`: ID of GPU where the failure has occurred
 
-**Example:** `autopilot.ibm.com/dcgm.level.3=ERR_2024-10-10_19.12.03UTC_page_retirement_row_remap.0`
+**Example:** 
+```
+labels:
+    autopilot.ibm.com/dcgm.level.3=ERR_2024-10-10_19.12.03UTC
+annotations:
+    autopilot.ibm.com/dcgm.level.3.output=memory_bandwidth.0.1.2.3
 
-If there are no errors, the value is set to `PASS_Year-Month-Date_Hour.Minute.UTC`.
+```
+
+If there are no errors, the value of `autopilot.ibm.com/dcgm.level.3` is set to `PASS_Year-Month-Date_Hour.Minute.UTC` while `autopilot.ibm.com/dcgm.level.3.output` will be empty.
 
 ### Logs and Metrics
 

--- a/alertmanager/alerts/healthchecks-alerts.yaml
+++ b/alertmanager/alerts/healthchecks-alerts.yaml
@@ -59,7 +59,7 @@ spec:
           A node reported errors after running DCGM level 3 - check health of nodes{{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
         summary: Node {{ $labels.node }} has GPU errors
       expr: |  
-        kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*EVICT.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""}
+        kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""}
       for: 5m
       labels:
         severity: critical

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -240,7 +240,7 @@ def patch_node(success, output):
         # If there is some other warning coming from other tests, i.e., ping or storage, we would overwrite this information. Let's play it safe at this point.
         result = "PASS_"+timestamp
     elif not success:
-        result = "ERR_"+timestamp+"_"+output
+        result = "ERR_"+timestamp
         general_health = "WARN"
         for error in dcgm_fatal_errors:
             unified = unify_string_format(error)
@@ -251,7 +251,10 @@ def patch_node(success, output):
         "metadata": {
             "labels": {
                 "autopilot.ibm.com/dcgm.level.3": result,
-                "autopilot.ibm.com/gpuhealth": general_health}
+                "autopilot.ibm.com/gpuhealth": general_health},
+            "annotations": {
+                "autopilot.ibm.com/dcgm.level.3.output": str(output)
+            }
         }
     }
     try:

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -25,7 +25,7 @@ def main():
     if "ABORT" not in result:
         print("[[ DCGM ]] Briefings completed. Continue with dcgm evaluation.")
         command = ['dcgmi', 'diag', '-j', '-r', args.run]
-        try_dcgm(command)
+        try_dcgm(command,args.run)
     else:
         print("[[ DCGM ]] ABORT")
         print(result)
@@ -182,7 +182,7 @@ def parse_selected_results(result: str, testpaths: str):
 
 
 
-def try_dcgm(command):
+def try_dcgm(command,run_level):
     result = subprocess.run(command, text=True, capture_output=True)
     return_code = result.returncode  # 0 for success
     if return_code != 0:
@@ -211,10 +211,10 @@ def try_dcgm(command):
             print("Host", nodename)
             print("[[ DCGM ]] FAIL")
         if args.label_node:
-            patch_node(success, output)
+            patch_node(success, output,run_level)
 
 
-def patch_node(success, output):
+def patch_node(success, output,run_level):
     now = datetime.datetime.now(datetime.timezone.utc)
     timestamp = now.strftime("%Y-%m-%d_%H.%M.%SUTC")
     result = ""
@@ -246,10 +246,10 @@ def patch_node(success, output):
     label = {
         "metadata": {
             "labels": {
-                "autopilot.ibm.com/dcgm.level.3": result,
+                f"autopilot.ibm.com/dcgm.level.{run_level}": result,
                 "autopilot.ibm.com/gpuhealth": general_health},
             "annotations": {
-                "autopilot.ibm.com/dcgm.level.3.output": str(output)
+                f"autopilot.ibm.com/dcgm.level.{run_level}.output": str(output)
             }
         }
     }

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -44,12 +44,13 @@ def parse_all_results(result: str):
     output = ""
     for category in tests_dict:
         for test in category['tests']:
-            if test['results'][0]['status'] == 'Fail':
-                success = False
-                print(test['name'], ":", test['results'][0]['status'])
-                output+=f'{unify_string_format(test["name"])}'
-                for entry in test['results']:
-                    output+=f'{"."+str(entry["gpu_id"]) if "gpu_id" in entry else "NoGPUid"}'
+            for result in test['results']:
+                if result['status'] == 'Fail':
+                    success = False
+                    print(test['name'], ":", test['results'][0]['status'])
+                    output+=f'{unify_string_format(test["name"])}'
+                    for entry in test['results']:
+                        output+=f'{"."+str(entry["gpu_id"]) if "gpu_id" in entry else "NoGPUid"}'
     return success, output
 
 

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -48,7 +48,11 @@ def parse_all_results(result: str):
             for result in test['results']:
                 if result['status'] == 'Fail':
                     success = False
-    return success, dcgm_dict
+                    if test_failing is False:
+                        output += f'{unify_string_format(test["name"])}'
+                        test_failing = True
+                    output += f'{"." + str(result["gpu_id"]) if "gpu_id" in result else "NoGPUid"}'
+    return success, output
 
 
 # parsing the json result string based on a comma-separated list of paths (levels separated by '.')
@@ -240,7 +244,7 @@ def patch_node(success, output,run_level):
         general_health = "WARN"
         for error in dcgm_fatal_errors:
             unified = unify_string_format(error)
-            if unified in result:
+            if unified in output:
                 general_health = "EVICT"
 
     label = {

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -48,11 +48,7 @@ def parse_all_results(result: str):
             for result in test['results']:
                 if result['status'] == 'Fail':
                     success = False
-                    if test_failing is False:
-                        output+=f'{unify_string_format(test["name"])}'
-                        test_failing=True
-                    output+=f'{"." + str(result["gpu_id"]) if "gpu_id" in result else "NoGPUid"}'
-    return success, output
+    return success, dcgm_dict
 
 
 # parsing the json result string based on a comma-separated list of paths (levels separated by '.')

--- a/autopilot-daemon/gpu-dcgm/entrypoint.py
+++ b/autopilot-daemon/gpu-dcgm/entrypoint.py
@@ -44,13 +44,14 @@ def parse_all_results(result: str):
     output = ""
     for category in tests_dict:
         for test in category['tests']:
+            test_failing=False
             for result in test['results']:
                 if result['status'] == 'Fail':
                     success = False
-                    print(test['name'], ":", test['results'][0]['status'])
-                    output+=f'{unify_string_format(test["name"])}'
-                    for entry in test['results']:
-                        output+=f'{"."+str(entry["gpu_id"]) if "gpu_id" in entry else "NoGPUid"}'
+                    if test_failing is False:
+                        output+=f'{unify_string_format(test["name"])}'
+                        test_failing=True
+                    output+=f'{"." + str(result["gpu_id"]) if "gpu_id" in result else "NoGPUid"}'
     return success, output
 
 


### PR DESCRIPTION
<!-- 

-=-=-=-= Replace the italic content with your own. -=-=-=-=
-=-=-=-=  Don't forget to update the GitHub Issue   -=-=-=-=
-=-=-=-=      your Pull-Request pertains to!        -=-=-=-=

 -->

# Summary

In this PR:

* we fix the parsing of the dcgm test results by looping through all the results in each category. 
* we store the output of the dcgm test in the `autopilot.ibm.com/dcgm.level.3.output` annotation to overcome the lenght limit of 64 character set on Kubernetes labels.
* we store the tests and results in different labels/annotations depending on the dcgm level

The result in case of errors is as following:
```
❯ oc get node adcpu014 -o yaml | grep -E 'autopilot|annotations|labels:'
  annotations:
    autopilot.ibm.com/dcgm.level.1.output: ""
    autopilot.ibm.com/dcgm.level.3.output: pcie.0.1.2.3gpu_memory.0.1.2.3diagnostic.0.1.2.3memory_bandwidth.0.1.2.3
  labels:
    autopilot.ibm.com/dcgm.level.1: PASS_2025-04-18_14.03.08UTC
    autopilot.ibm.com/dcgm.level.3: ERR_2025-04-18_14.07.58UTC
    autopilot.ibm.com/gpuhealth: EVICT
...
```

## Scope and Impact

- _API Changes?_ No 
- _Should any users or specific teams be notified of breaking changes?_ If users process labels output to take decision, they should be notified about these changes

## GitHub Issue
- #68 

## How was this Pull-Request Tested and Validated?

This Pull-Request was validated using a failing gpu node in our bare-metal cluster 

## Pull-Request Reminders

- Does the [Autopilot Readme](https://github.com/IBM/autopilot?tab=readme-ov-file#ai-training-autopilot) require updates?
  - No

- Are there any new software dependencies introduced to this Pull-Request?
  - No
