### PR TITLE
Update health check intervals

### DIFF
--- a/autopilot-daemon/pkg/utils/functions.go
+++ b/autopilot-daemon/pkg/utils/functions.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"context"
 
@@ -212,4 +214,16 @@ func PatchNode(label string, nodename string, force bool) error {
 	}
 	klog.Info("Node patched with label ", label)
 	return nil
+}
+
+// ParseInterval parses a duration string and returns the duration.
+// @param interval: duration string like "1h30m", "45m", or "2s"
+// @return: time.Duration or error if the format is invalid
+func ParseInterval(interval string) (time.Duration, error) {
+	d, err := time.ParseDuration(interval)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration format %q: must be like '1h30m', '45m' or '2s'", interval)
+	}
+
+	return d, nil
 }

--- a/autopilot-daemon/pkg/utils/functions_test.go
+++ b/autopilot-daemon/pkg/utils/functions_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseDuration tests the ParseDuration function for various valid and invalid inputs.
+func TestParseInterval(t *testing.T) {
+	// Test valid durations
+	validDurations := []string{"1h30m", "45m", "2s", "1h", "30m", "2h15m30s", "0"}
+	validResults := []time.Duration{time.Hour + 30*time.Minute, 45 * time.Minute, 2 * time.Second, time.Hour, 30 * time.Minute, 2*time.Hour + 15*time.Minute + 30*time.Second, 0}
+	for i, duration := range validDurations {
+		result, err := ParseInterval(duration)
+		if err != nil {
+			t.Errorf("Expected no error for %q, got %v", duration, err)
+		}
+		if result != validResults[i] {
+			t.Errorf("Expected %v for %q, got %v", validResults[i], duration, result)
+		}
+	}
+
+	// Test invalid durations
+	invalidDurations := []string{"1h2x", "abc", "123"}
+	for _, duration := range invalidDurations {
+		_, err := ParseInterval(duration)
+		if err == nil {
+			t.Errorf("Expected error for %q, got nil", duration)
+		}
+	}
+}

--- a/helm-charts/autopilot/README.md
+++ b/helm-charts/autopilot/README.md
@@ -25,8 +25,8 @@ Notice that, in this heterogeneous case, the GPU health checks will error out in
 - Autopilot runs tests periodically. The default is set to every hour and 4 hours for regular and deep diagnostics respectively, but these can be customized be changing the following
 
 ```yaml
-repeat: <hours> # periodic health checks timer (default 1h)
-invasive: <hours> # deeper diagnostic timer (default 4h, 0 to disable)
+repeat: <interval-format> # periodic health checks timer (default 1h) (e.g., 1h, 30m, 15s)
+invasive: <interval-format> # deeper diagnostic timer (default 4h, 0 to disable) (e.g., 1h, 30m, 15s)
 ```
 
 - The list of GPU errors considered fatal as a result of a dcgmi run, can be customized through the `DCGM_FATAL_ERRORS` environment variable. This is used to label nodes with extra WARN/EVICT labels. The list defaults to [PCIe,NVLink,ECC,GPU Memory] and refers to https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/feature-overview.html#id3

--- a/helm-charts/autopilot/values.yaml
+++ b/helm-charts/autopilot/values.yaml
@@ -9,11 +9,11 @@ image:
 # It is recommended to set a threshold that is 25% or lower of the expected peak PCIe bandwidth capability, which maps to maximum peak from 16 lanes to 4 lanes. For example, for a PCIe Gen4x16, reported peak bandwidth is 63GB/s. A degradation at 25% is 15.75GB/s, which corresponds to PCIe Gen4x4. The measured bandwidth is expected to be at least 80% of the expected peak PCIe generation bandwidth.
 PCIeBW: 4
 
-# Timer for periodic checks, in hours
-repeat: 1
+# Timer for periodic checks, in interval format (e.g., 1h, 30m, 15s).
+repeat: 1h
 
-# Timer for periodic invasive checks, in hours (e.g., dcgmi diag -r 3). Set to 0 to disable (for non nvidia gpu systems)
-invasive: 4
+# Timer for periodic invasive checks (e.g., dcgmi diag -r 3), in interval format (e.g., 1h, 30m, 15s). Set to 0 to disable (for non nvidia gpu systems)
+invasive: 4h
 
 # Image pull secret if the image is in a private repository
 pullSecrets:


### PR DESCRIPTION
<!-- 

-=-=-=-= Replace the italic content with your own. -=-=-=-=
-=-=-=-=  Don't forget to update the GitHub Issue   -=-=-=-=
-=-=-=-=      your Pull-Request pertains to!        -=-=-=-=

 -->

# Summary

- Instead of using fixed hourly intervals for health checks, I added support for flexible time inputs like 1h, 30m, or 45s. This allows users to set short or long check intervals easily, while keeping the code simple.

## Scope and Impact

- There are no API changes — only the input flags and Helm chart values have been updated. The repeat and invasive fields were changed from `int` to `string,` so they can now accept duration formats like "30s", "5m", or "1h". These values are parsed as `time.Duration` in Go.
- This is a breaking change for all users (Helm, etc.) — existing numeric values for repeat (w) and invasive (invasive-check-timer) flags will no longer work unless they’re updated to valid duration strings.

## GitHub Issue
- None

## How was this Pull-Request Tested and Validated?

- To test the type change, I created a new test file named `functions_test.go` under `autopilot-daemon/pkg/utils`. This test module includes various input cases to verify that the interval parsing works correctly with the new string-based durations. Run `go test -v ./...` to see the results.

## Pull-Request Reminders

- Does the [Autopilot Readme](https://github.com/IBM/autopilot?tab=readme-ov-file#ai-training-autopilot) require updates?
  - Yes, changes have been made.

- Are there any new software dependencies introduced to this Pull-Request?
  - No
