### PR TITLE
Add a worker pool for health check go-routines

### DIFF
--- a/autopilot-daemon/pkg/cmd/main.go
+++ b/autopilot-daemon/pkg/cmd/main.go
@@ -25,6 +25,7 @@ func main() {
 	v := flag.String("loglevel", "2", "Log level")
 	repeat := flag.String("w", "24h", "Run all tests periodically on each node. Time set in interval format. Defaults to 24h")
 	invasive := flag.String("invasive-check-timer", "4h", "Run invasive checks (e.g., dcgmi level 3) on each node when GPUs are free. Time set in interval format. Defaults to 4h. Set to 0 to avoid invasive checks")
+	workersLimit := flag.Int("workers", 0, "Number of workers to use for concurrent tasks. Defaults to 0 which uses 2*number_of_logical_CPU_cores")
 
 	flag.Parse()
 
@@ -126,6 +127,11 @@ func main() {
 
 	// Create a WorkerPool to handle tasks concurrently
 	numCPU := runtime.NumCPU()
+	if *workersLimit > 0 {
+		// if user has set a limit, use it
+		numCPU = *workersLimit
+	}
+
 	workerPool := worker.CreateWorkerPool(2 * numCPU) // use 2 workers per CPU core
 	klog.Infof("Starting WorkerPool with %d workers", 2*numCPU)
 

--- a/autopilot-daemon/pkg/worker/enum.go
+++ b/autopilot-daemon/pkg/worker/enum.go
@@ -1,0 +1,10 @@
+package worker
+
+// TaskType represents the type of task to be processed by the worker pool.
+// it is either a periodic check or an invasive check.
+type TaskType int
+
+const (
+	TaskPeriodicCheck TaskType = iota + 1
+	TaskInvasiveCheck
+)

--- a/autopilot-daemon/pkg/worker/enum.go
+++ b/autopilot-daemon/pkg/worker/enum.go
@@ -8,3 +8,15 @@ const (
 	TaskPeriodicCheck TaskType = iota + 1
 	TaskInvasiveCheck
 )
+
+// String returns a string representation of the TaskType.
+func (t TaskType) String() string {
+	switch t {
+	case TaskPeriodicCheck:
+		return "Periodic Check"
+	case TaskInvasiveCheck:
+		return "Invasive Check"
+	default:
+		return "Unknown Task Type"
+	}
+}

--- a/autopilot-daemon/pkg/worker/pool.go
+++ b/autopilot-daemon/pkg/worker/pool.go
@@ -1,6 +1,8 @@
 package worker
 
-import "sync"
+import (
+	"sync"
+)
 
 // WorkerPool manages a pool of go-routines that process tasks concurrently.
 type WorkerPool struct {

--- a/autopilot-daemon/pkg/worker/pool.go
+++ b/autopilot-daemon/pkg/worker/pool.go
@@ -19,7 +19,7 @@ func CreateWorkerPool(numberOfWorkers int) *WorkerPool {
 
 	// start the specified number of workers
 	for i := 0; i < numberOfWorkers; i++ {
-		go worker(taskQueue, syncMap)
+		go worker(taskQueue, syncMap) // start a worker goroutine, see worker.go for implementation
 	}
 
 	return &WorkerPool{
@@ -35,7 +35,8 @@ func (wp *WorkerPool) Submit(task TaskType) {
 		return // task is already running, do not submit again
 	}
 
-	// mark the task as running
+	// mark the task as running, so it won't be submitted again
+	// the worker will remove it from runningTasks when done
 	wp.runningTasks.Store(task, struct{}{})
 	wp.taskQueue <- task
 }

--- a/autopilot-daemon/pkg/worker/pool.go
+++ b/autopilot-daemon/pkg/worker/pool.go
@@ -2,6 +2,8 @@ package worker
 
 import (
 	"sync"
+
+	"k8s.io/klog/v2"
 )
 
 // WorkerPool manages a pool of go-routines that process tasks concurrently.
@@ -32,6 +34,7 @@ func CreateWorkerPool(numberOfWorkers int) *WorkerPool {
 func (wp *WorkerPool) Submit(task TaskType) {
 	// check if the task is running
 	if _, exists := wp.runningTasks.Load(task); exists {
+		klog.InfoS("Task already running, skipping submission", "task", task.String())
 		return // task is already running, do not submit again
 	}
 
@@ -39,4 +42,6 @@ func (wp *WorkerPool) Submit(task TaskType) {
 	// the worker will remove it from runningTasks when done
 	wp.runningTasks.Store(task, struct{}{})
 	wp.taskQueue <- task
+
+	klog.InfoS("Task submitted to worker pool", "task", task.String())
 }

--- a/autopilot-daemon/pkg/worker/pool.go
+++ b/autopilot-daemon/pkg/worker/pool.go
@@ -1,0 +1,24 @@
+package worker
+
+// WorkerPool manages a pool of go-routines that process tasks concurrently.
+type WorkerPool struct {
+	taskChannel chan TaskType
+}
+
+// CreateWorkerPool initializes a new WorkerPool with a specified number of workers.
+func CreateWorkerPool(numberOfWorkers int) *WorkerPool {
+	taskChannel := make(chan TaskType)
+
+	for i := 0; i < numberOfWorkers; i++ {
+		go worker(taskChannel)
+	}
+
+	return &WorkerPool{
+		taskChannel: taskChannel,
+	}
+}
+
+// Submit adds a task to the worker pool for processing.
+func (wp *WorkerPool) Submit(task TaskType) {
+	wp.taskChannel <- task
+}

--- a/autopilot-daemon/pkg/worker/worker.go
+++ b/autopilot-daemon/pkg/worker/worker.go
@@ -1,0 +1,14 @@
+package worker
+
+func worker(c chan TaskType) {
+	for task := range c {
+		switch task {
+		case TaskPeriodicCheck:
+			// Handle periodic check
+		case TaskInvasiveCheck:
+			// Handle invasive check
+		default:
+			// Handle unknown task type
+		}
+	}
+}

--- a/autopilot-daemon/pkg/worker/worker.go
+++ b/autopilot-daemon/pkg/worker/worker.go
@@ -1,6 +1,11 @@
 package worker
 
-func worker(c chan TaskType) {
+import "sync"
+
+// worker is a function that processes tasks from the task queue.
+// it runs in a separate goroutine and listens for tasks to process.
+// it removes the task from the runningTasks map once completed.
+func worker(c chan TaskType, sm *sync.Map) {
 	for task := range c {
 		switch task {
 		case TaskPeriodicCheck:
@@ -10,5 +15,8 @@ func worker(c chan TaskType) {
 		default:
 			// Handle unknown task type
 		}
+
+		// mark the task as completed
+		sm.Delete(task)
 	}
 }

--- a/autopilot-daemon/pkg/worker/worker.go
+++ b/autopilot-daemon/pkg/worker/worker.go
@@ -13,6 +13,8 @@ import (
 // it removes the task from the runningTasks map once completed.
 func worker(c chan TaskType, sm *sync.Map) {
 	for task := range c {
+		klog.InfoS("Processing task", "task", task.String())
+
 		switch task {
 		case TaskPeriodicCheck:
 			healthcheck.PeriodicCheck()
@@ -24,5 +26,6 @@ func worker(c chan TaskType, sm *sync.Map) {
 
 		// mark the task as completed
 		sm.Delete(task)
+		klog.InfoS("Task completed", "task", task.String())
 	}
 }

--- a/autopilot-daemon/pkg/worker/worker.go
+++ b/autopilot-daemon/pkg/worker/worker.go
@@ -1,6 +1,12 @@
 package worker
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/IBM/autopilot/pkg/healthcheck"
+
+	"k8s.io/klog/v2"
+)
 
 // worker is a function that processes tasks from the task queue.
 // it runs in a separate goroutine and listens for tasks to process.
@@ -9,11 +15,11 @@ func worker(c chan TaskType, sm *sync.Map) {
 	for task := range c {
 		switch task {
 		case TaskPeriodicCheck:
-			// Handle periodic check
+			healthcheck.PeriodicCheck()
 		case TaskInvasiveCheck:
-			// Handle invasive check
+			healthcheck.InvasiveCheck()
 		default:
-			// Handle unknown task type
+			klog.Errorf("Unknown task type: %v", task)
 		}
 
 		// mark the task as completed

--- a/helm-charts/autopilot/templates/autopilot.yaml
+++ b/helm-charts/autopilot/templates/autopilot.yaml
@@ -51,7 +51,7 @@ spec:
            - sh
            - -c
            - |
-             /usr/local/bin/autopilot --port {{ .Values.service.port }} --loglevel={{ .Values.loglevel }} --bw {{ .Values.PCIeBW }} --w {{ .Values.repeat }} --invasive-check-timer {{ .Values.invasive }}
+             /usr/local/bin/autopilot --port {{ .Values.service.port }} --loglevel={{ .Values.loglevel }} --bw {{ .Values.PCIeBW }} --w {{ .Values.repeat }} --invasive-check-timer {{ .Values.invasive }} --workers {{ .Values.workers }}
           imagePullPolicy: {{ .Values.image.pullPolicy }} 
           name: autopilot
           securityContext:

--- a/helm-charts/autopilot/values.yaml
+++ b/helm-charts/autopilot/values.yaml
@@ -5,6 +5,9 @@ image:
   repository: quay.io/autopilot/autopilot
   pullPolicy: Always
 
+# Workers for concurrent tasks. Defaults to 0 which uses 2*number_of_logical_CPU_cores (depends on the resource limits).
+workers: 2
+
 # Bandwidth threshold below which PCIe links are considered defective (Gb/s)
 # It is recommended to set a threshold that is 25% or lower of the expected peak PCIe bandwidth capability, which maps to maximum peak from 16 lanes to 4 lanes. For example, for a PCIe Gen4x16, reported peak bandwidth is 63GB/s. A degradation at 25% is 15.75GB/s, which corresponds to PCIe Gen4x4. The measured bandwidth is expected to be at least 80% of the expected peak PCIe generation bandwidth.
 PCIeBW: 4


### PR DESCRIPTION
<!-- 

-=-=-=-= Replace the italic content with your own. -=-=-=-=
-=-=-=-=  Don't forget to update the GitHub Issue   -=-=-=-=
-=-=-=-=      your Pull-Request pertains to!        -=-=-=-=

 -->

# Summary

- Right now, using short intervals for health checks is causing problems. The main Go routine gets blocked, and health checks start to overlap, which wastes system resources. To fix this, we suggested using a worker pool. This runs health checks in separate Go routines so the main routine doesn’t get blocked. Also, if a health check is already running, any new ones that come in during that time are dropped. This way, each health check only runs once at a time, without overlap or blocking.

## Scope and Impact

- No API changes.
- The health check logic is now handled by a new module called worker located in autopilot-daemon/pkg. We’ve updated cmd/main.go to support a new flag called --workers, which sets the maximum size of the worker pool. This change is also reflected in the Helm chart values.yaml to allow configuration of the pool size. If the value is set to 0, the system will automatically assign 2 workers per logical CPU core. Otherwise, the user-defined pool size will be used. For now, I recommend setting the pool size to 2.

## GitHub Issue
- None

## How was this Pull-Request Tested and Validated?

- Built a new image `ghcr.io/amirhnajafiz/autopilot:sha-3a76e7c`.
- Executed an instance of new Autopilot with Helm Chart on a 3 node Kubernetes cluster (1 controller, 2 GPU nodes).

### Helm Chart Values

```yaml
anajafizadeh@kctl:~/fsl/sunyibm$ cat autopilot/values.yaml
# Default values for the Autopilot DaemonSet.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.
image:
  repository: ghcr.io/amirhnajafiz/autopilot #quay.io/autopilot/autopilot
  tag: sha-3a76e7c
  pullPolicy: Always

# Workers for concurrent tasks. Defaults to 0 which uses 2*number_of_logical_CPU_cores (depends on the resource limits).
workers: 2

# Bandwidth threshold below which PCIe links are considered defective (Gb/s)
# It is recommended to set a threshold that is 25% or lower of the expected peak PCIe bandwidth capability, which maps to maximum peak from 16 lanes to 4 lanes. For example, for a PCIe Gen4x16, reported peak bandwidth is 63GB/s. A degradation at 25% is 15.75GB/s, which corresponds to PCIe Gen4x4. The measured bandwidth is expected to be at least 80% of the expected peak PCIe generation bandwidth.
PCIeBW: 4

# Timer for periodic checks, in hours
repeat: 15s

# Timer for periodic invasive checks, in hours (e.g., dcgmi diag -r 3). Set to 0 to disable (for non nvidia gpu systems)
invasive: 30s

...
```

### Pods and logs

<img width="801" height="54" alt="Screen Shot 2025-08-06 at 12 27 42 PM" src="https://github.com/user-attachments/assets/38b1b78c-2d9a-43ed-8f67-fbef2ddf1aec" />

<img width="515" height="67" alt="Screen Shot 2025-08-06 at 12 22 23 PM" src="https://github.com/user-attachments/assets/8df446aa-78e7-4e91-b46c-1e745efd0de8" />

```sh
anajafizadeh@kctl:~/fsl/sunyibm$ kubectl logs -n autopilot autopilot-mpx2n | grep "Running a periodic check"
Defaulted container "autopilot" out of: autopilot, device-plugin-validation (init)
I0806 16:02:39.623145       7 healthcheck.go:17] Running a periodic check
I0806 16:02:54.624244       7 healthcheck.go:17] Running a periodic check
I0806 16:03:09.624157       7 healthcheck.go:17] Running a periodic check
I0806 16:03:24.624331       7 healthcheck.go:17] Running a periodic check
I0806 16:03:39.624464       7 healthcheck.go:17] Running a periodic check
I0806 16:03:54.623782       7 healthcheck.go:17] Running a periodic check
I0806 16:04:09.623547       7 healthcheck.go:17] Running a periodic check
I0806 16:04:24.624150       7 healthcheck.go:17] Running a periodic check
I0806 16:04:39.624421       7 healthcheck.go:17] Running a periodic check
I0806 16:04:54.624438       7 healthcheck.go:17] Running a periodic check
I0806 16:05:09.623947       7 healthcheck.go:17] Running a periodic check
I0806 16:05:24.623921       7 healthcheck.go:17] Running a periodic check
I0806 16:05:39.624037       7 healthcheck.go:17] Running a periodic check
```

```sh
anajafizadeh@kctl:~/fsl/sunyibm$ kubectl logs -n autopilot autopilot-4gjp6 | grep "Running a periodic check"
Defaulted container "autopilot" out of: autopilot, device-plugin-validation (init)
I0806 16:05:08.163434       7 healthcheck.go:17] Running a periodic check
I0806 16:05:38.164806       7 healthcheck.go:17] Running a periodic check
I0806 16:06:08.164229       7 healthcheck.go:17] Running a periodic check
I0806 16:06:38.164170       7 healthcheck.go:17] Running a periodic check
I0806 16:07:08.164261       7 healthcheck.go:17] Running a periodic check
I0806 16:07:38.163962       7 healthcheck.go:17] Running a periodic check
I0806 16:08:08.164634       7 healthcheck.go:17] Running a periodic check
I0806 16:08:38.164744       7 healthcheck.go:17] Running a periodic check
I0806 16:09:08.164202       7 healthcheck.go:17] Running a periodic check
I0806 16:09:38.164636       7 healthcheck.go:17] Running a periodic check
I0806 16:10:08.164235       7 healthcheck.go:17] Running a periodic check
I0806 16:10:38.164370       7 healthcheck.go:17] Running a periodic check
I0806 16:11:08.164418       7 healthcheck.go:17] Running a periodic check
I0806 16:11:38.164357       7 healthcheck.go:17] Running a periodic check
I0806 16:12:08.163866       7 healthcheck.go:17] Running a periodic check
I0806 16:12:38.163964       7 healthcheck.go:17] Running a periodic check
I0806 16:13:08.164548       7 healthcheck.go:17] Running a periodic check
I0806 16:13:38.163890       7 healthcheck.go:17] Running a periodic check
I0806 16:14:08.164925       7 healthcheck.go:17] Running a periodic check
I0806 16:14:38.164208       7 healthcheck.go:17] Running a periodic check
I0806 16:15:08.163903       7 healthcheck.go:17] Running a periodic check
I0806 16:15:38.164278       7 healthcheck.go:17] Running a periodic check
I0806 16:16:08.164369       7 healthcheck.go:17] Running a periodic check
I0806 16:16:38.164610       7 healthcheck.go:17] Running a periodic check
```

```sh
anajafizadeh@kctl:~/fsl/sunyibm$ kubectl logs -n autopilot autopilot-mpx2n | grep "Trying to run an invasive check"
Defaulted container "autopilot" out of: autopilot, device-plugin-validation (init)
I0806 16:03:09.624142       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:03:39.624458       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:04:09.623547       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:04:39.624373       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:05:09.623927       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:05:39.624069       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:06:09.624482       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:06:39.623918       7 healthcheck.go:32] Trying to run an invasive check
```

```sh
anajafizadeh@kctl:~/fsl/sunyibm$ kubectl logs -n autopilot autopilot-4gjp6 | grep "Trying to run an invasive check"
Defaulted container "autopilot" out of: autopilot, device-plugin-validation (init)
I0806 16:05:38.164827       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:06:08.164175       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:06:38.164084       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:07:08.164261       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:07:38.163887       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:08:08.164679       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:08:38.164718       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:09:08.164154       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:09:38.164671       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:10:08.164164       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:10:38.164350       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:11:08.164330       7 healthcheck.go:32] Trying to run an invasive check
I0806 16:11:38.164298       7 healthcheck.go:32] Trying to run an invasive check
```

<img width="844" height="686" alt="Screen Shot 2025-08-06 at 12 23 17 PM" src="https://github.com/user-attachments/assets/bf1f531f-c883-4df2-bed3-f89d55d5ab43" />

## Pull-Request Reminders

- Does the [Autopilot Readme](https://github.com/IBM/autopilot?tab=readme-ov-file#ai-training-autopilot) require updates?
  - No

- Are there any new software dependencies introduced to this Pull-Request?
  - No
